### PR TITLE
fix example's subscriber node name to 'subscriber' from 'publisher'

### DIFF
--- a/examples/publisher_subscriber/subscriber/main.go
+++ b/examples/publisher_subscriber/subscriber/main.go
@@ -22,7 +22,7 @@ func run() error {
 	}
 	defer rclgo.Uninit()
 
-	node, err := rclgo.NewNode("publisher", "")
+	node, err := rclgo.NewNode("subscriber", "")
 	if err != nil {
 		return fmt.Errorf("failed to create node: %v", err)
 	}


### PR DESCRIPTION
See: #18